### PR TITLE
Fix OpenZeppelin contract links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The open-source code is available on GitHub, encouraging collaboration and furth
 
 ## 🧱 Smart Contract Primitives (by [🔹OpenZeppelin](https://github.com/OpenZeppelin/compact-contracts))
 
-- **[🔹 Fungible Token](https://github.com/OpenZeppelin/compact-contracts/tree/main/contracts/fungibleToken)** — Midnight-native equivalent of ERC-20 for tokens like stablecoins or rewards  
-- **[🔹 Non-Fungible Token (NFT)](https://github.com/OpenZeppelin/compact-contracts/tree/main/contracts/nonFungibleToken)** — Create and manage NFTs on Midnight using Compact  
-- **[🔹 MultiToken (ERC-1155)](https://github.com/OpenZeppelin/compact-contracts/tree/main/contracts/multitoken)** — Efficient multi-asset standard supporting both fungible and non-fungible tokens  
+- **[🔹 Fungible Token](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/FungibleToken.compact)** — Midnight-native equivalent of ERC-20 for tokens like stablecoins or rewards  
+- **[🔹 Non-Fungible Token (NFT)](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/NonFungibleToken.compact)** — Create and manage NFTs on Midnight using Compact  
+- **[🔹 MultiToken (ERC-1155)](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/MultiToken.compact)** — Efficient multi-asset standard supporting both fungible and non-fungible tokens  
 
 ## 🧑‍💻 Starter Templates
 *Community-created boilerplates or dev scaffolds*


### PR DESCRIPTION
The links for the OpenZeppelin token contracts were 404'ing. Updated them to the new URLs.

> [!NOTE]
> You **can** pin these links to a specific commit so they won't 404 if the file layout changes again, but they could end up pointing at outdated/insecure versions of the contract. I decided **not** to pin them as I felt that sometimes getting a 404 is better than _never_ getting updates. If you do land on a 404 it is an obvious problem, and you're still in the right repo so it is easy to rectify. If you pin it, there's no obvious indicator that you're viewing an outdated version of the contract.