### PR TITLE
Add Hydra Stake Protocol to midnight community dapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Projects marked with 🏆 are hackathon winners
 - **[Midnight Vote](https://github.com/armsves/midnightVotingW3PN)** — An anonymous governance and polling app
 - **[KYC Midnight](https://github.com/joacolinares/kyc-midnight)** – Know Your Customer (KYC) attestation system
 - **[Midnauction](https://github.com/eryxcoop/midnauction)** – Sealed-bid round-based auction platform
+- **[Hydra Stake](https://github.com/statera-protocol/hydra-stake-protocol)** - Hydra Stake Protocol is a privacy-preserving liquid staking solution built on Midnight blockchain. It allows users to stake their assets while maintaining liquidity through liquid staking tokens (LST), enabling participation in DeFi while earning staking rewards.
 - **[Gracias Esteban](https://github.com/nicolasLuduena/2025-hackathon-midnight)** – Decentralized asset tokenization platform, representing real-world assets as privacy-preserving digital shares.
 ---
 


### PR DESCRIPTION
This adds Hydra stake protocol by lucent labs to the midnight awesome dapps list.

Hydra stake won 1st place in defi track for the Midnight London Summit, 2025