### PR TITLE
feat: add DPO2U Midnight Relayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ _Community-created boilerplates or dev scaffolds_
 _Tools that help other devs build, test, deploy, or index_
 
 - [Compact Playground](https://github.com/Olanetsoft/compact-playground) - Browser-based Compact smart contract compiler, built as a companion to Learn Compact
+- [DPO2U Midnight Relayer](https://github.com/fredericosanntana/dpo2u-midnight-relayer) - Cross-chain compliance relay for Midnight Network with ZK proofs
 - [Explorer](https://github.com/AIQUANT-Tech/explorer) - Simple block explorer for Midnight networks
 - [Midnight Indexer](https://github.com/semsorock/midnight-indexer) - An indexing tool for querying Midnight blockchain data
 - [Midnight MCP](https://github.com/Olanetsoft/midnight-mcp) - MCP server giving AI assistants access to the Midnight blockchain — search contracts, analyze code, explore docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Awesome Midnight dApps [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
+> This project is built on the Midnight Network.
+
+
 > A curated list of awesome Midnight dApps, tools, and resources
 
 ## Contents


### PR DESCRIPTION
The DPO2U Relayer is the first custom bridge that reads ZK-private compliance attestations from the Midnight Network and propagates them to EVM chains. Any DeFi protocol can call isCompliant(address) on Base, Polkadot Hub, or Hedera — without ever touching the private data stored on Midnight.

Midnight Network → EVM compliance attestation bridge (Base, Polkadot, Hedera)

