### PR TITLE
Add Midnight Authenticator to Identity & Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [Ethiopian Identity Wallet](https://github.com/HeikkiRuhanen/ethiopian-identity-wallet) - Self-Sovereign Identity (SSI) for verifying crypto wallet eligibility for National Stablecoin holding
 - [Face Recognition Midnight](https://github.com/laughtt/face-recognition-midnight) - Facial recognition used to gate ZK-verified identity contracts
 - 🏆 [KYC Midnight](https://github.com/joacolinares/kyc-midnight) - Know Your Customer (KYC) attestation system - LATAM Hack winner
+- [Midnight Authenticator](https://github.com/subc0der/midnight-authenticator) - Zero-knowledge TOTP authenticator that proves code validity without revealing secrets
 - [Midnight Cloak](https://github.com/subc0der/midnight-cloak) - Zero-knowledge identity verification SDK enabling dApps to verify user attributes (age, credentials) without exposing personal data
 - [Private Data Management](https://github.com/Edgxtech/pdm-demo-app) - Private data management demonstration using decentralised ledgers ([article](https://medium.com/itnext/private-data-management-using-decentralised-ledgers-b972c6855e48))
 - [SentinelDID](https://github.com/bytewizard42i/SentinelDID-poc) - ZK identity and access prototype with selective attributes


### PR DESCRIPTION
Adds [Midnight Authenticator](https://github.com/subc0der/midnight-authenticator) - a zero-knowledge TOTP authenticator for Midnight.

## Checklist

- [x] `midnightntwrk` and `compact` GitHub topics added
- [x] Attribution in README: "Built on the Midnight Network"
- [x] Contract deployed to Preprod
- [x] Apache 2.0 license
- [x] Open source

## About

Midnight Authenticator enables users to prove they possess a valid TOTP code without revealing the underlying secret or the code itself. Unlike traditional 2FA where codes are transmitted in plaintext, this authenticator uses zero-knowledge proofs for privacy-preserving authentication.