### PR TITLE
fix: correct YAML syntax in add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: read
-      pull-requests: read    steps:
+      pull-requests: read
+    steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/midnightntwrk/projects/75


### PR DESCRIPTION
## Summary

The `add-to-project.yml` workflow has a syntax error — `pull-requests: read` and `steps:` are on the same line (missing newline), which makes the entire workflow file unparseable. GitHub Actions silently ignores it, so the workflow has not been running.

This PR adds the missing newline so the workflow parses correctly.

## Related

- shieldedtech/shielded-iac#872
- [SRE-2083](https://shielded.atlassian.net/browse/SRE-2083)

[SRE-2083]: https://shielded.atlassian.net/browse/SRE-2083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ