### PR TITLE
Move Wybe and Scaffold to dormant_projects — builder confirmed inactive

### DIFF
--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -13,5 +13,6 @@
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission
 
 ## Starter Templates
+-  [Scaffold Midnight](https://github.com/kaleababayneh/scaffold-midnight) - Full-stack dev scaffold with Midnight integration
 -  [Wybe](https://github.com/lamg/wybe) - A minimal and expressive contract language for Midnight
 

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -12,3 +12,6 @@
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission
 
+## Starter Templates
+-  [Wybe](https://github.com/lamg/wybe) - A minimal and expressive contract language for Midnight
+


### PR DESCRIPTION
## Summary

Moves [Wybe](https://github.com/lamg/wybe) from **Starter Templates** to `dormant_projects/`.

## Dormancy criteria

- No substantive commits in the last 6+ months (last activity: April 2025)
- Builder confirmed the project is no longer actively maintained 

## Courtesy check

Contacted the original builder by Discord, who confirmed the project is inactive.

## Changes

- Removed Wybe entry from `README.md` (Starter Templates section)
- Added Wybe entry to `dormant_projects/README.md` (Starter Templates section)

---

*Part of the [Identify Dormant Midnight dApps](https://github.com/midnightntwrk/midnight-awesome-dapps) initiative to keep the ecosystem list accurate and highlight projects available for community revival.*