### PR TITLE
Move "Midnames" to dormant_projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ _Tools that help other devs build, test, deploy, or index_
 
 _Privacy-preserving identity, credentials, and proof of personhood_
 
-- [🔹 Midnames](https://github.com/midnames/core) - ZK-powered DID and credential registry with selective disclosure
 - [🔹 Midnight Identity](https://github.com/bricktowers/midnight-identity) - Brick Towers' ZK identity system for self-issued credentials
 - [AirLog](https://github.com/hbrazier01/airlog) - Privacy preserving aviation maintenance record verification system built with Midnight Compact smart contracts
 - [AutoDiscovery](https://github.com/SpyCrypto/AutoDiscovery) - Privacy-preserving legal discovery automation with jurisdiction-aware compliance, ZK proofs, and dual-ledger architecture

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -11,4 +11,5 @@
 ## Gaming
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission
+- [🔹 Midnames](https://github.com/midnames/core) - ZK-powered DID and credential registry with selective disclosure
 


### PR DESCRIPTION
Summary

This PR moves the Midnames project to the dormant_projects/ section of the Awesome Midnight dApps list.

Reasoning
The repository (https://github.com/midnames/core) shows no meaningful development activity for approximately 10 months
No recent commits beyond minor or non-substantive updates
No active issue discussions or pull requests indicating ongoing development
Courtesy Check
Attempted to contact the project maintainer to confirm current status (awaiting response / no response received yet)
Why this matters

Keeping inactive projects clearly identified helps:

Developers focus on actively maintained tools
The community understand the current state of the ecosystem
Potential contributors identify projects that may be open for revival
Tag

#dormant-project