### PR TITLE
chore: move Face Recognition Midnight to dormant projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [Blockenfy](https://github.com/kevan1/kyc-midnight-hackathon) - Decentralized identity platform built on the Midnight network. It enables user data registration and validation through zkProof, integrating the Lace wallet and ensuring privacy in KYC processes
 - [DPO2U Midnight](https://github.com/fredericosanntana/dpo2u-midnight) - Autonomous LGPD/GDPR compliance protocol with ZK-attested privacy scores. AI agents audit data protection practices off-chain and record immutable attestations on Midnight via four Compact smart contracts (ComplianceRegistry, AgentRegistry, FeeDistributor, Treasury)
 - [Ethiopian Identity Wallet](https://github.com/HeikkiRuhanen/ethiopian-identity-wallet) - Self-Sovereign Identity (SSI) for verifying crypto wallet eligibility for National Stablecoin holding
-- [Face Recognition Midnight](https://github.com/laughtt/face-recognition-midnight) - Facial recognition used to gate ZK-verified identity contracts
 - 🏆 [KYC Midnight](https://github.com/joacolinares/kyc-midnight) - Know Your Customer (KYC) attestation system - LATAM Hack winner
 - [Midnight Authenticator](https://github.com/subc0der/midnight-authenticator) - Zero-knowledge TOTP authenticator that proves code validity without revealing secrets
 - [Midnight Cloak](https://github.com/subc0der/midnight-cloak) - Zero-knowledge identity verification SDK enabling dApps to verify user attributes (age, credentials) without exposing personal data

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -8,6 +8,9 @@
 
 > Found something useful? Star the repo and open an issue to let the original builder know. They might surprise you.
 
+## Identity & Privacy
+- [Face Recognition Midnight](https://github.com/laughtt/face-recognition-midnight) - Facial recognition used to gate ZK-verified identity contracts
+
 ## Gaming
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission


### PR DESCRIPTION
## Summary
- Move Face Recognition Midnight from Identity & Privacy in the main README to dormant projects
- Project has had no activity for 13+ months

## Evidence
- **Repo:** https://github.com/laughtt/face-recognition-midnight
- No commits, issues, or PRs in 13+ months

## Outreach Attempts
- Opened an issue on the repository — no response
- Attempted to reach the maintainer through the Midnight Community Discord — could not find them

## Notes
This is a curation change only — the project is preserved in `dormant_projects/README.md` and can be relisted if the maintainer returns.