### PR TITLE
chore: move Midnight Indexer to dormant projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [DPO2U Midnight Relayer](https://github.com/fredericosanntana/dpo2u-midnight-relayer) - Cross-chain compliance relay for Midnight Network with ZK proofs
 - [Midnight Explorer](https://github.com/Tech-Expansion/midnight-explorer-web) - The leading block explorer on the Midnight Network, proudly built by TexLabs - [Website](https://www.midnightexplorer.com/)
 - [Explorer](https://github.com/AIQUANT-Tech/explorer) - Simple block explorer for Midnight networks
-- [Midnight Indexer](https://github.com/semsorock/midnight-indexer) - An indexing tool for querying Midnight blockchain data
 - [Midnight Live View](https://github.com/Midnight-Scripts/Midnight-Live-View) - A simple script that allows users to monitor key information about their Midnight node
 - [Midnight Local Playground](https://github.com/0xshae/midnight-playground) - Local dev environment: run full node, indexer, and proof server via Docker; fund and deploy Compact contracts with Lace on "Undeployed" — no testnet or faucet. Includes Hello World contract and CLI
 - [Midnight MCP](https://github.com/Olanetsoft/midnight-mcp) - MCP server giving AI assistants access to the Midnight blockchain — search contracts, analyze code, explore docs

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -8,6 +8,9 @@
 
 > Found something useful? Star the repo and open an issue to let the original builder know. They might surprise you.
 
+## Developer Tools
+- [Midnight Indexer](https://github.com/semsorock/midnight-indexer) - An indexing tool for querying Midnight blockchain data
+
 ## Gaming
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission


### PR DESCRIPTION
## Summary
- Move Midnight Indexer from Developer Tools in the main README to dormant projects
- Project has had no activity for 10+ months

## Evidence
- **Repo:** https://github.com/semsorock/midnight-indexer
- No commits, issues, or PRs in 10+ months

## Outreach Attempts
- Opened an issue on the repository — no response
- Attempted to reach the maintainer through the Midnight Community Discord — could not find them

## Notes
This is a curation change only — the project is preserved in `dormant_projects/README.md` and can be relisted if the maintainer returns.