### PR TITLE
chore: move Midnight Vote to dormant projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ _Interactive, zero-knowledge-powered games_
 ## Governance
 
 - [FundAGoal](https://github.com/codeBigInt/fundagoal) - Crowdfunding smart contracts for verified projects
-- [Midnight Vote](https://github.com/armsves/midnightVotingW3PN) - An anonymous governance and polling app
 
 ## Healthcare
 

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -8,6 +8,9 @@
 
 > Found something useful? Star the repo and open an issue to let the original builder know. They might surprise you.
 
+## Governance
+- [Midnight Vote](https://github.com/armsves/midnightVotingW3PN) - An anonymous governance and polling app
+
 ## Gaming
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission


### PR DESCRIPTION
## Summary
- Move Midnight Vote from Governance in the main README to dormant projects
- Project has had no activity for 10+ months

## Evidence
- **Repo:** https://github.com/armsves/midnightVotingW3PN
- No commits, issues, or PRs in 10+ months

## Outreach Attempts
- Opened an issue on the repository — no response
- Attempted to reach the maintainer through the Midnight Community Discord — could not find them

## Notes
This is a curation change only — the project is preserved in `dormant_projects/README.md` and can be relisted if the maintainer returns.