### PR TITLE
Move Midnight Bank to dormant_projects (inactive + builder confirmation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [Asset Tokenization Platform](https://github.com/nicolasLuduena/2025-hackathon-midnight) - Decentralized asset tokenization platform
 - [dMarket](https://github.com/bochaco/dmarket) - A decentralized e-commerce marketplace that utilizes a three-party escrow system on the Midnight Network, incorporating asymmetric encryption and zero-knowledge proofs (zk-proofs) to ensure robust user privacy and security
 - [Hydra Stake](https://github.com/statera-protocol/hydra-stake-protocol) - Hydra Stake Protocol is a privacy-preserving liquid staking solution. It allows users to stake their assets while maintaining liquidity through liquid staking tokens (LST), enabling participation in DeFi while earning staking rewards
-- [Midnight Bank](https://github.com/nel349/midnight-bank) - Privacy-first banking dApp
 - [Midnight Escrow](https://github.com/tusharpamnani/midnight-escrow) - Privacy-preserving escrow contract demonstrating confidential conditional payments using zk proofs on Midnight
 - [Midnauction](https://github.com/eryxcoop/midnauction) - Sealed-bid round-based auction platform
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -25,3 +25,6 @@
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission
 
+## Finance & DeFi
+- [Midnight Bank](https://github.com/nel349/midnight-bank) - Privacy-first banking dApp
+


### PR DESCRIPTION
### Summary

Moving Midnight Bank from active dApps list to dormant_projects/.

### Reasoning

- No substantive code commits since approximately October 2025
- No meaningful issue or PR activity in the last 6 months
- Meets the inactivity criteria defined in the repo guidelines

### Courtesy Check

- Posted a courtesy check in the community before proceeding
- Original builder responded and confirmed the project can be moved to dormant due to limited bandwidth
- 

### Builder Response

"hey! you can move it to dormant. I don't have the bandwidth to update it now. will do it at later time. thanks for the heads up!"

### Proof
<img width="1025" height="1079" alt="image" src="https://github.com/user-attachments/assets/cf445b9c-ef0a-43e6-a426-67bd7c8e70a7" />
