### PR TITLE
chore: categorize inactive repositories for maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [Hydra Stake](https://github.com/statera-protocol/hydra-stake-protocol) - Hydra Stake Protocol is a privacy-preserving liquid staking solution. It allows users to stake their assets while maintaining liquidity through liquid staking tokens (LST), enabling participation in DeFi while earning staking rewards
 - [Midnight Bank](https://github.com/nel349/midnight-bank) - Privacy-first banking dApp
 - [Midnight Escrow](https://github.com/tusharpamnani/midnight-escrow) - Privacy-preserving escrow contract demonstrating confidential conditional payments using zk proofs on Midnight
-- [Midnauction](https://github.com/eryxcoop/midnauction) - Sealed-bid round-based auction platform
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp
 - [Statera Protocol](https://github.com/statera-protocol/statera-protocol-midnight) - Over-collateralized stablecoin protocol with modular dApp framework

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -25,3 +25,5 @@
 - [Midnight Battleship](https://github.com/mediocrehacker/midnight-battleship) - A ZK-powered battleship game
 - [Midnight Sea Battle Hackathon](https://github.com/eddex/midnight-sea-battle-hackathon) - Jan & Eddex's SeaBattle submission
 
+## Finance
+- [Midnauction](https://github.com/eryxcoop/midnauction) - Sealed-bid round-based auction platform


### PR DESCRIPTION
### Description
This PR moves the current repository to the `dormant-repo` folder. 

### Context
Following the recent status inquiry regarding repository activity, this change is being made to keep the workspace organized. Moving this to the dormant folder helps maintain a clear overview of active projects while ensuring this codebase remains archived and accessible for future reference.

### Notes
- This is a non-destructive move.
- If activity resumes, the repository can be moved back to the active directory.