### PR TITLE
add compact.vim to developer tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ _Tools that help other devs build, test, deploy, or index_
 - 🧰 [midnight-wallet-cli](https://github.com/nel349/midnight-wallet-cli-hub) - Standalone terminal wallet for Midnight with multi-wallet management, DApp connector server (`mn serve`), local network management, and MCP server for AI agents - [npm](https://www.npmjs.com/package/midnight-wallet-cli) - [Connector](https://www.npmjs.com/package/midnight-wallet-connector)
 - [Compact Playground](https://github.com/Olanetsoft/compact-playground) - Browser-based Compact smart contract compiler, built as a companion to Learn Compact
 - [Compact Syntax Highlighting for VS Code](https://github.com/foxytanuki/compact-vscode) - VS Code extension providing syntax highlighting for Compact smart contracts
+- [compact.vim](https://github.com/1NickPappas/compact.vim) - Vim/Neovim plugin for Compact with syntax highlighting, tree-sitter support, filetype detection, smart indentation, and compiler quickfix integration
 - [🔹 OpenZeppelin Compact Tools](https://github.com/OpenZeppelin/compact-tools) - Tools for compiling, building, and testing Compact smart contracts
 - [🔹 Web3Fast Midnight](https://midnight.web3fast.dev/) - Fast development tools and services for Midnight blockchain
 - [DPO2U Midnight Relayer](https://github.com/fredericosanntana/dpo2u-midnight-relayer) - Cross-chain compliance relay for Midnight Network with ZK proofs

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ _Tools that help other devs build, test, deploy, or index_
 - 🧰 [midnight-wallet-cli](https://github.com/nel349/midnight-wallet-cli-hub) - Standalone terminal wallet for Midnight with multi-wallet management, DApp connector server (`mn serve`), local network management, and MCP server for AI agents - [npm](https://www.npmjs.com/package/midnight-wallet-cli) - [Connector](https://www.npmjs.com/package/midnight-wallet-connector)
 - [Compact Playground](https://github.com/Olanetsoft/compact-playground) - Browser-based Compact smart contract compiler, built as a companion to Learn Compact
 - [Compact Syntax Highlighting for VS Code](https://github.com/foxytanuki/compact-vscode) - VS Code extension providing syntax highlighting for Compact smart contracts
-- [compact.vim](https://github.com/1NickPappas/compact.vim) - Vim/Neovim plugin for Compact with syntax highlighting, tree-sitter support, filetype detection, smart indentation, and compiler quickfix integration
+- [compact.vim](https://github.com/1NickPappas/compact.vim) - Vim and Neovim plugin for the Compact language with syntax highlighting, Tree-sitter support, filetype detection, smart indentation, and compiler quickfix integration.
 - [🔹 OpenZeppelin Compact Tools](https://github.com/OpenZeppelin/compact-tools) - Tools for compiling, building, and testing Compact smart contracts
 - [🔹 Web3Fast Midnight](https://midnight.web3fast.dev/) - Fast development tools and services for Midnight blockchain
 - [DPO2U Midnight Relayer](https://github.com/fredericosanntana/dpo2u-midnight-relayer) - Cross-chain compliance relay for Midnight Network with ZK proofs


### PR DESCRIPTION
## Overview
Add compact.vim to the Developer Tools section so Midnight builders can discover Vim/Neovim editor support for Compact, including syntax highlighting, tree-sitter support, and compiler quickfix integration.
## Submission Checklist
- [x] Useful pull request description
- [ ] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new TODOs introduced
## Links
- Project: https://github.com/1NickPappas/compact.vim