### PR TITLE
Remove Scaffold Midnight and Wybe links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ _Community-created boilerplates or dev scaffolds_
 
 - [🔹 Edda Labs Midnight Starter](https://github.com/eddalabs/midnight-starter-template) - Complete template with smart contracts, tests, UI, and all batteries included to kickstart your project
 - [Midnightpy](https://github.com/Techgethr/midnightpy) - Midnight smart contract bindings for Python
-- [Scaffold Midnight](https://github.com/kaleababayneh/scaffold-midnight) - Full-stack dev scaffold with Midnight integration
-- [Wybe](https://github.com/lamg/wybe) - A minimal and expressive contract language for Midnight
 
 ## Developer Tools
 


### PR DESCRIPTION
Removed links to Scaffold Midnight and Wybe from the README.