### PR TITLE
docs: restructure README for newcomer navigation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ Ecosystem tracking tools scan README files for these phrases. Custom wording may
 
 **How to choose a row:**
 
-- Most DApp sections (Finance and DeFi, Gaming, Identity and Privacy, Governance, Healthcare, Smart Contract Primitives): use the **built on** sentence.
+- Most DApp sections (Finance & DeFi, Gaming, Identity & Privacy, Governance, Healthcare, Smart Contract Primitives): use the **built on** sentence.
 - SDKs, wallets, indexers, explorers, infrastructure: use the **integrates with** sentence.
 - CLIs, scaffolds, libraries, and developer tools in **Developer Tools** or **Starter Templates**: use the **extends** sentence when that best describes the project. If the project is primarily a DApp or contract repo, use **built on** instead.
 
@@ -238,7 +238,7 @@ Add your entry under the section that best matches your project. If you are unsu
 
 | Section | What belongs here |
 |---------|-------------------|
-| **Getting Started** | Official Midnight team projects for education and onboarding only. Community submissions do not go here. |
+| **Example DApps (Start Here)** | Official Midnight team projects for education and onboarding only. Community submissions do not go here. |
 | **Smart Contract Primitives** | Reusable contract building blocks (tokens, standards, shared libraries). |
 | **Starter Templates** | Boilerplates, scaffolds, and project templates for new Midnight builds. |
 | **Developer Tools** | CLIs, SDKs, compilers, indexers, explorers, wallets, MCP servers, and other tools that help developers build, test, deploy, or index. |
@@ -247,8 +247,9 @@ Add your entry under the section that best matches your project. If you are unsu
 | **Gaming** | Games and interactive experiences on Midnight. |
 | **Governance** | Voting, crowdfunding, and community governance. |
 | **Healthcare** | Health-related applications using Midnight. |
-| **Learning Resources** | Tutorials, courses, documentation, and community-created educational content. |
 | **Dormant Projects** | Do not add new projects here. See [Updating or removing an entry](#updating-or-removing-an-entry). |
+| **Learning Resources** | Tutorials, courses, documentation, and community-created educational content. |
+| **Community** | Official community channels, forums, ambassador programs, and fellowship links. Ask maintainers before adding or changing official links. |
 
 Official ecosystem partners may use the 🔹 marker. Hackathon winners may use 🏆 where applicable. Do not add these markers unless your project qualifies.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A curated list of dApps, tools, and resources built on the [Midnight Network](ht
 
 ## Contents
 
-- [Example dApps (Start Here)](#example-dapps-start-here)
+- [Example DApps (Start Here)](#example-dapps-start-here)
 - [Smart Contract Primitives](#smart-contract-primitives)
 - [Starter Templates](#starter-templates)
 - [Developer Tools](#developer-tools)
@@ -32,9 +32,9 @@ A curated list of dApps, tools, and resources built on the [Midnight Network](ht
 > [!IMPORTANT]
 > Community-contributed projects are shared for inspiration and exploration. These repositories are not maintained by the Midnight team, and their functionality may vary.
 
-## Example dApps (Start Here)
+## Example DApps (Start Here)
 
-_Official dApps and tools maintained by the Midnight team for education and onboarding._
+_Official DApps and tools maintained by the Midnight team for education and onboarding._
 
 - [Example Counter](https://github.com/midnightntwrk/example-counter) - Simple increment/decrement app demonstrating state management
 - [Hello World Compact](https://github.com/Olanetsoft/hello-world-compact) - Minimal Hello World smart contract for Midnight. Deploy to Preprod and store/read messages on-chain

--- a/README.md
+++ b/README.md
@@ -1,45 +1,40 @@
-# Awesome Midnight dApps [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+<div align="center">
 
-> This project is built on the Midnight Network.
+# Awesome Midnight dApps
 
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> A curated list of awesome Midnight dApps, tools, and resources
+A curated list of dApps, tools, and resources built on the [Midnight Network](https://midnight.network).
+
+</div>
+
+---
 
 ## Contents
 
-- [Awesome Midnight dApps ](#awesome-midnight-dapps-)
-  - [Contents](#contents)
-  - [Getting Started](#getting-started)
-  - [Smart Contract Primitives](#smart-contract-primitives)
-  - [Starter Templates](#starter-templates)
-  - [Developer Tools](#developer-tools)
-  - [Finance \& DeFi](#finance--defi)
-  - [Identity \& Privacy](#identity--privacy)
-  - [Gaming](#gaming)
-  - [Governance](#governance)
-  - [Dormant Projects](#dormant-projects)
-  - [Learning Resources](#learning-resources)
-    - [Documentation](#documentation)
-    - [Getting Started](#getting-started-1)
-    - [Tutorials](#tutorials)
-    - [Community](#community)
-  - [Community Projects](#community-projects)
-  - [Contributing](#contributing)
-  - [Submission Criteria](#submission-criteria)
-  - [License](#license)
+- [Example dApps (Start Here)](#example-dapps-start-here)
+- [Smart Contract Primitives](#smart-contract-primitives)
+- [Starter Templates](#starter-templates)
+- [Developer Tools](#developer-tools)
+- [Finance & DeFi](#finance--defi)
+- [Identity & Privacy](#identity--privacy)
+- [Gaming](#gaming)
+- [Governance](#governance)
+- [Healthcare](#healthcare)
+- [Dormant Projects](#dormant-projects)
+- [Learning Resources](#learning-resources)
+- [Community](#community)
+- [Contributing](#contributing)
 
-> [!IMPORTANT]  
+> [!NOTE]
+> 🔹 = Official Midnight Ecosystem Partner &nbsp;·&nbsp; 🏆 = Hackathon winner
+
+> [!IMPORTANT]
 > Community-contributed projects are shared for inspiration and exploration. These repositories are not maintained by the Midnight team, and their functionality may vary.
 
-> [!NOTE]  
-> 🔹 = Official Midnight Ecosystem Partner  
-> 🏆 = Hackathon winners
+## Example dApps (Start Here)
 
-<!-- ## 🔦 Featured Project -->
-
-## Getting Started
-
-_Official dApps and tools maintained by the Midnight team (for education + onboarding)_
+_Official dApps and tools maintained by the Midnight team for education and onboarding._
 
 - [Example Counter](https://github.com/midnightntwrk/example-counter) - Simple increment/decrement app demonstrating state management
 - [Hello World Compact](https://github.com/Olanetsoft/hello-world-compact) - Minimal Hello World smart contract for Midnight. Deploy to Preprod and store/read messages on-chain
@@ -47,9 +42,7 @@ _Official dApps and tools maintained by the Midnight team (for education + onboa
 - [Example ZK Loan](https://github.com/midnightntwrk/example-zkloan) - ZK-powered loan contract demonstrating private state management
 - [Midnight Kitties](https://github.com/midnightntwrk/example-kitties) - A full stack dApp using the NFT smart contract library to deploy Crypto Kitties on Midnight network
 - [NFT Smart Contract Library](https://github.com/riusricardo/midnight-contracts) - A comprehensive smart contract library for NFTs on the Midnight network
-- [Midnight Local Dev](https://github.com/midnightntwrk/midnight-local-dev) -  
-Local development environment for building and testing Midnight  
-smart contracts without connecting to Preprod
+- [Midnight Local Dev](https://github.com/midnightntwrk/midnight-local-dev) - Local development environment for building and testing Midnight smart contracts without connecting to Preprod
 - [Create Midnight App](https://github.com/midnightntwrk/create-mn-app) - CLI tool for scaffolding Midnight smart contracts with automated generation, enhanced data types, a pre-generated wallet, and a full contract-deploy pipeline, available on [npm](https://www.npmjs.com/package/create-midnight-app)
 
 ## Smart Contract Primitives
@@ -59,17 +52,16 @@ smart contracts without connecting to Preprod
   - [🔹 MultiToken](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/MultiToken.compact) - ERC-1155 equivalent supporting both fungible and non-fungible tokens
   - [🔹 NonFungibleToken](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/NonFungibleToken.compact) - NFT implementation for Midnight
 
-
 ## Starter Templates
 
-_Community-created boilerplates or dev scaffolds_
+_Community-created boilerplates and dev scaffolds._
 
 - [🔹 Edda Labs Midnight Starter](https://github.com/eddalabs/midnight-starter-template) - Complete template with smart contracts, tests, UI, and all batteries included to kickstart your project
 - [Midnightpy](https://github.com/Techgethr/midnightpy) - Midnight smart contract bindings for Python
 
 ## Developer Tools
 
-_Tools that help other devs build, test, deploy, or index_
+_Tools that help builders compile, test, deploy, index, or explore Midnight._
 
 - 🧰 [midnight-wallet-cli](https://github.com/nel349/midnight-wallet-cli-hub) - Standalone terminal wallet for Midnight with multi-wallet management, DApp connector server (`mn serve`), local network management, and MCP server for AI agents - [npm](https://www.npmjs.com/package/midnight-wallet-cli) - [Connector](https://www.npmjs.com/package/midnight-wallet-connector)
 - [Compact Playground](https://github.com/Olanetsoft/compact-playground) - Browser-based Compact smart contract compiler, built as a companion to Learn Compact
@@ -89,7 +81,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [Midnight Playground](https://midnight-playground-one.vercel.app/) - Online Compact IDE for writing, compiling, and building smart contracts with syntax error detection
 - [MidnightForge](https://github.com/bytewizard42i/MidnightForge) - Infrastructure scripts and DevOps for Midnight dApp deployment
 - [Midnightscan](https://github.com/mediocrehacker/Midnightscan) - Blockchain scanner for tracking Midnight contract deployments
-
 - [Nightforge](https://github.com/cadalt0/NIGHTFORGE) - CLI development toolkit for building, deploying, and managing Midnight smart contracts with project scaffolding, compilation, and proof server orchestration
 - [NightGate](https://github.com/ODATANO/NIGHTGATE) - Self contained Midnight Indexer packaged as an SAP CAP plugin normalizes chain data into CAP entities, and exposes it through OData V4 Services.
 - [Pelagos SDK](https://github.com/0xAtelerix/sdk) - Go SDK for building appchains with native Midnight, EVM, and non-EVM integration
@@ -109,7 +100,7 @@ _Tools that help other devs build, test, deploy, or index_
 
 ## Identity & Privacy
 
-_Privacy-preserving identity, credentials, and proof of personhood_
+_Privacy-preserving identity, credentials, and proof of personhood._
 
 - [🔹 Midnames](https://github.com/midnames/core) - ZK-powered DID and credential registry with selective disclosure
 - [🔹 Midnight Identity](https://github.com/bricktowers/midnight-identity) - Brick Towers' ZK identity system for self-issued credentials
@@ -121,21 +112,15 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [Midnight Cloak](https://github.com/subc0der/midnight-cloak) - Zero-knowledge identity verification SDK enabling dApps to verify user attributes (age, credentials) without exposing personal data
 - [Private Data Management](https://github.com/Edgxtech/pdm-demo-app) - Private data management demonstration using decentralised ledgers ([article](https://medium.com/itnext/private-data-management-using-decentralised-ledgers-b972c6855e48))
 - [SentinelDID](https://github.com/bytewizard42i/SentinelDID-poc) - ZK identity and access prototype with selective attributes
-- [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia’s digital sovereignty challenges
-
-# Topics
-
+- [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia's digital sovereignty challenges
 
 ## Gaming
 
-_Interactive, zero-knowledge-powered games_
+_Interactive, zero-knowledge-powered games._
 
 - 🕹️ [Midnight Starship](https://github.com/nel349/midnight-starship) - Galaga-style space shooter with privacy-first on-chain leaderboard using ZK selective disclosure, built with midnight-wallet-connector
 - [🔹 Midnight Seabattle](https://github.com/bricktowers/midnight-seabattle) - SeaBattle implementation by Brick Towers
-
-- [Midnight DiceRoll Game](https://github.com/Kali-Decoder/Midnight-Dice-Roll) - Midnight Dice Roll is a reference implementation of a verifiable dice game built using Midnight’s Compact smart contracts.
-
-
+- [Midnight DiceRoll Game](https://github.com/Kali-Decoder/Midnight-Dice-Roll) - Midnight Dice Roll is a reference implementation of a verifiable dice game built using Midnight's Compact smart contracts.
 
 ## Governance
 
@@ -143,29 +128,29 @@ _Interactive, zero-knowledge-powered games_
 
 ## Healthcare
 
-- [NextMed](https://github.com/NextMed-main/Main) - healthcare platform enabling zk medical data analysis
+- [NextMed](https://github.com/NextMed-main/Main) - Healthcare platform enabling ZK medical data analysis
 
 ## Dormant Projects
 
-Projects that are no longer actively maintained live in the [Dormant Projects](./dormant_projects/README.md) folder. These projects and their code are preserved and available for reference, adoption, or revival by anyone in the community.
+Projects no longer actively maintained live in the [Dormant Projects](./dormant_projects/README.md) folder, kept around so anyone can reference, fork, or pick them back up.
 
-# Learning Resources
+## Learning Resources
 
 ### Documentation
 
 - [Midnight Docs](https://docs.midnight.network/) - Official documentation
-- [Developer Academy](https://academy.midnight.network/) - Build data protection apps with midnight
+- [Developer Academy](https://academy.midnight.network/) - Build data protection apps with Midnight
 - [Dev Diaries](https://docs.midnight.network/blog) - Technical blog posts and development insights
 - [Kachina Paper](https://docs.midnight.network/learn/understanding-midnights-technology/kachina) - Privacy model paper
 - [Tokenomics Paper](https://45047878.fs1.hubspotusercontent-na1.net/hubfs/45047878/Midnight-Tokenomics-And-Incentives-Whitepaper.pdf) - NIGHT/DUST economics
 
-### Getting Started
+### Setup Guides
 
 - [Proof Server Setup](https://docs.midnight.network/guides/run-proof-server)
 - [Testnet Faucet](https://docs.midnight.network/guides/acquire-tokens)
 - [Compact Compiler](https://docs.midnight.network/relnotes/compact-tools)
 
-### Community Created Tutorials
+### Community Tutorials
 
 - [Learn Compact](https://github.com/Olanetsoft/learn-compact) - Interactive book and exercise collection for learning Compact, Midnight's ZK smart contract language
 - [Compact By Example](https://github.com/Olanetsoft/compact-by-example) - Learn Midnight's Compact language through practical, real-world examples
@@ -173,9 +158,7 @@ Projects that are no longer actively maintained live in the [Dormant Projects](.
 - [🔹 Mesh Midnight](https://midnight.meshjs.dev/) - A unified repository that brings together packages, examples, and documentation to streamline development
 - [Korean Tutorial](https://github.com/jungmyeong96/midnight_tutorial) - Step-by-step development guide for Korean-speaking developers
 
-
-
-### Join Our Community
+## Community
 
 - [Midnight Network Discord](https://discord.com/invite/midnightnetwork)
 - [Follow Midnightntwrk on X](https://x.com/MidnightNtwrk)
@@ -184,23 +167,18 @@ Projects that are no longer actively maintained live in the [Dormant Projects](.
 - [Nightforce - Ambassadors](https://midnight.network/nightforce-ambassador-program)
 - [Aliit - Technical Fellowship](https://midnight.network/aliit)
 
+## Contributing
 
----
+Pull requests are welcome. The short version:
 
-# Contributing
+1. Add your project in alphabetical order within the appropriate section
+2. Use the format: `[Project Name](link) - Brief description`
+3. Project must include working Compact code, proper attribution, and represent a real use case on Midnight
 
-**Contributions to this repo are welcome! Please:**
-
-1. Add projects in alphabetical order within sections
-2. Use format: `[name](link) - Brief description`
-3. Ensure projects are open source and functional
-
-## Submission Criteria
-
-Projects must include working Compact code, proper attribution, and represent 
-a real use case built on Midnight Network. See [CONTRIBUTING.md](CONTRIBUTING.md) 
-for full review guidelines before opening a PR.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full review guidelines. First-time contributors are especially welcome - feel free to ask in Discord if anything is unclear.
 
 ## License
 
 [![Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+Released under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,45 +1,40 @@
-# Awesome Midnight dApps [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+<div align="center">
 
-> This project is built on the Midnight Network.
+# Awesome Midnight dApps
 
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> A curated list of awesome Midnight dApps, tools, and resources
+A curated list of dApps, tools, and resources built on the [Midnight Network](https://midnight.network).
+
+</div>
+
+---
 
 ## Contents
 
-- [Awesome Midnight dApps ](#awesome-midnight-dapps-)
-  - [Contents](#contents)
-  - [Getting Started](#getting-started)
-  - [Smart Contract Primitives](#smart-contract-primitives)
-  - [Starter Templates](#starter-templates)
-  - [Developer Tools](#developer-tools)
-  - [Finance \& DeFi](#finance--defi)
-  - [Identity \& Privacy](#identity--privacy)
-  - [Gaming](#gaming)
-  - [Governance](#governance)
-  - [Dormant Projects](#dormant-projects)
-  - [Learning Resources](#learning-resources)
-    - [Documentation](#documentation)
-    - [Getting Started](#getting-started-1)
-    - [Tutorials](#tutorials)
-    - [Community](#community)
-  - [Community Projects](#community-projects)
-  - [Contributing](#contributing)
-  - [Submission Criteria](#submission-criteria)
-  - [License](#license)
+- [Example dApps (Start Here)](#example-dapps-start-here)
+- [Smart Contract Primitives](#smart-contract-primitives)
+- [Starter Templates](#starter-templates)
+- [Developer Tools](#developer-tools)
+- [Finance & DeFi](#finance--defi)
+- [Identity & Privacy](#identity--privacy)
+- [Gaming](#gaming)
+- [Governance](#governance)
+- [Healthcare](#healthcare)
+- [Dormant Projects](#dormant-projects)
+- [Learning Resources](#learning-resources)
+- [Community](#community)
+- [Contributing](#contributing)
 
-> [!IMPORTANT]  
+> [!NOTE]
+> 🔹 = Official Midnight Ecosystem Partner &nbsp;·&nbsp; 🏆 = Hackathon winner
+
+> [!IMPORTANT]
 > Community-contributed projects are shared for inspiration and exploration. These repositories are not maintained by the Midnight team, and their functionality may vary.
 
-> [!NOTE]  
-> 🔹 = Official Midnight Ecosystem Partner  
-> 🏆 = Hackathon winners
+## Example dApps (Start Here)
 
-<!-- ## 🔦 Featured Project -->
-
-## Getting Started
-
-_Official dApps and tools maintained by the Midnight team (for education + onboarding)_
+_Official dApps and tools maintained by the Midnight team for education and onboarding._
 
 - [Example Counter](https://github.com/midnightntwrk/example-counter) - Simple increment/decrement app demonstrating state management
 - [Hello World Compact](https://github.com/Olanetsoft/hello-world-compact) - Minimal Hello World smart contract for Midnight. Deploy to Preprod and store/read messages on-chain
@@ -47,9 +42,7 @@ _Official dApps and tools maintained by the Midnight team (for education + onboa
 - [Example ZK Loan](https://github.com/midnightntwrk/example-zkloan) - ZK-powered loan contract demonstrating private state management
 - [Midnight Kitties](https://github.com/midnightntwrk/example-kitties) - A full stack dApp using the NFT smart contract library to deploy Crypto Kitties on Midnight network
 - [NFT Smart Contract Library](https://github.com/riusricardo/midnight-contracts) - A comprehensive smart contract library for NFTs on the Midnight network
-- [Midnight Local Dev](https://github.com/midnightntwrk/midnight-local-dev) -  
-Local development environment for building and testing Midnight  
-smart contracts without connecting to Preprod
+- [Midnight Local Dev](https://github.com/midnightntwrk/midnight-local-dev) - Local development environment for building and testing Midnight smart contracts without connecting to Preprod
 - [Create Midnight App](https://github.com/midnightntwrk/create-mn-app) - CLI tool for scaffolding Midnight smart contracts with automated generation, enhanced data types, a pre-generated wallet, and a full contract-deploy pipeline, available on [npm](https://www.npmjs.com/package/create-midnight-app)
 
 ## Smart Contract Primitives
@@ -59,17 +52,16 @@ smart contracts without connecting to Preprod
   - [🔹 MultiToken](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/MultiToken.compact) - ERC-1155 equivalent supporting both fungible and non-fungible tokens
   - [🔹 NonFungibleToken](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/NonFungibleToken.compact) - NFT implementation for Midnight
 
-
 ## Starter Templates
 
-_Community-created boilerplates or dev scaffolds_
+_Community-created boilerplates and dev scaffolds._
 
 - [🔹 Edda Labs Midnight Starter](https://github.com/eddalabs/midnight-starter-template) - Complete template with smart contracts, tests, UI, and all batteries included to kickstart your project
 - [Midnightpy](https://github.com/Techgethr/midnightpy) - Midnight smart contract bindings for Python
 
 ## Developer Tools
 
-_Tools that help other devs build, test, deploy, or index_
+_Tools that help builders compile, test, deploy, index, or explore Midnight._
 
 - 🧰 [midnight-wallet-cli](https://github.com/nel349/midnight-wallet-cli-hub) - Standalone terminal wallet for Midnight with multi-wallet management, DApp connector server (`mn serve`), local network management, and MCP server for AI agents - [npm](https://www.npmjs.com/package/midnight-wallet-cli) - [Connector](https://www.npmjs.com/package/midnight-wallet-connector)
 - [midnight-wallet-kit](https://www.npmjs.com/package/midnight-wallet-kit) - Lightweight toolkit for seamless wallet integration in Midnight dApps
@@ -93,7 +85,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [Midnight Playground](https://midnight-playground-one.vercel.app/) - Online Compact IDE for writing, compiling, and building smart contracts with syntax error detection
 - [MidnightForge](https://github.com/bytewizard42i/MidnightForge) - Infrastructure scripts and DevOps for Midnight dApp deployment
 - [Midnightscan](https://github.com/mediocrehacker/Midnightscan) - Blockchain scanner for tracking Midnight contract deployments
-
 - [Nightforge](https://github.com/cadalt0/NIGHTFORGE) - CLI development toolkit for building, deploying, and managing Midnight smart contracts with project scaffolding, compilation, and proof server orchestration
 - [NightGate](https://github.com/ODATANO/NIGHTGATE) - Self contained Midnight Indexer packaged as an SAP CAP plugin normalizes chain data into CAP entities, and exposes it through OData V4 Services.
 - [Pelagos SDK](https://github.com/0xAtelerix/sdk) - Go SDK for building appchains with native Midnight, EVM, and non-EVM integration
@@ -113,7 +104,7 @@ _Tools that help other devs build, test, deploy, or index_
 
 ## Identity & Privacy
 
-_Privacy-preserving identity, credentials, and proof of personhood_
+_Privacy-preserving identity, credentials, and proof of personhood._
 
 - [🔹 Midnames](https://github.com/midnames/core) - ZK-powered DID and credential registry with selective disclosure
 - [🔹 Midnight Identity](https://github.com/bricktowers/midnight-identity) - Brick Towers' ZK identity system for self-issued credentials
@@ -129,21 +120,15 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [Proof-of-Age Gate](https://github.com/tomiin/midnight-proof-of-age) - Prove you meet a minimum age without revealing your birth year; ZK selective disclosure in Compact, with a React frontend wired to the 1AM wallet
 - [SentinelDID](https://github.com/bytewizard42i/SentinelDID-poc) - ZK identity and access prototype with selective attributes
 - [ZIP](https://github.com/oluwatobiss/zip-midnight-mlh-202605-hack) - A privacy-first Proof-of-Humanity application
-- [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia’s digital sovereignty challenges
-
-# Topics
-
+- [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia's digital sovereignty challenges
 
 ## Gaming
 
-_Interactive, zero-knowledge-powered games_
+_Interactive, zero-knowledge-powered games._
 
 - 🕹️ [Midnight Starship](https://github.com/nel349/midnight-starship) - Galaga-style space shooter with privacy-first on-chain leaderboard using ZK selective disclosure, built with midnight-wallet-connector
 - [🔹 Midnight Seabattle](https://github.com/bricktowers/midnight-seabattle) - SeaBattle implementation by Brick Towers
-
-- [Midnight DiceRoll Game](https://github.com/Kali-Decoder/Midnight-Dice-Roll) - Midnight Dice Roll is a reference implementation of a verifiable dice game built using Midnight’s Compact smart contracts.
-
-
+- [Midnight DiceRoll Game](https://github.com/Kali-Decoder/Midnight-Dice-Roll) - Midnight Dice Roll is a reference implementation of a verifiable dice game built using Midnight's Compact smart contracts.
 
 ## Governance
 
@@ -151,29 +136,29 @@ _Interactive, zero-knowledge-powered games_
 
 ## Healthcare
 
-- [NextMed](https://github.com/NextMed-main/Main) - healthcare platform enabling zk medical data analysis
+- [NextMed](https://github.com/NextMed-main/Main) - Healthcare platform enabling ZK medical data analysis
 
 ## Dormant Projects
 
-Projects that are no longer actively maintained live in the [Dormant Projects](./dormant_projects/README.md) folder. These projects and their code are preserved and available for reference, adoption, or revival by anyone in the community.
+Projects no longer actively maintained live in the [Dormant Projects](./dormant_projects/README.md) folder, kept around so anyone can reference, fork, or pick them back up.
 
-# Learning Resources
+## Learning Resources
 
 ### Documentation
 
 - [Midnight Docs](https://docs.midnight.network/) - Official documentation
-- [Developer Academy](https://academy.midnight.network/) - Build data protection apps with midnight
+- [Developer Academy](https://academy.midnight.network/) - Build data protection apps with Midnight
 - [Dev Diaries](https://docs.midnight.network/blog) - Technical blog posts and development insights
 - [Kachina Paper](https://docs.midnight.network/learn/understanding-midnights-technology/kachina) - Privacy model paper
 - [Tokenomics Paper](https://45047878.fs1.hubspotusercontent-na1.net/hubfs/45047878/Midnight-Tokenomics-And-Incentives-Whitepaper.pdf) - NIGHT/DUST economics
 
-### Getting Started
+### Setup Guides
 
 - [Proof Server Setup](https://docs.midnight.network/guides/run-proof-server)
 - [Testnet Faucet](https://docs.midnight.network/guides/acquire-tokens)
 - [Compact Compiler](https://docs.midnight.network/relnotes/compact-tools)
 
-### Community Created Tutorials
+### Community Tutorials
 
 - [Learn Compact](https://github.com/Olanetsoft/learn-compact) - Interactive book and exercise collection for learning Compact, Midnight's ZK smart contract language
 - [Compact By Example](https://github.com/Olanetsoft/compact-by-example) - Learn Midnight's Compact language through practical, real-world examples
@@ -181,9 +166,7 @@ Projects that are no longer actively maintained live in the [Dormant Projects](.
 - [🔹 Mesh Midnight](https://midnight.meshjs.dev/) - A unified repository that brings together packages, examples, and documentation to streamline development
 - [Korean Tutorial](https://github.com/jungmyeong96/midnight_tutorial) - Step-by-step development guide for Korean-speaking developers
 
-
-
-### Join Our Community
+## Community
 
 - [Midnight Network Discord](https://discord.com/invite/midnightnetwork)
 - [Follow Midnightntwrk on X](https://x.com/MidnightNtwrk)
@@ -192,23 +175,18 @@ Projects that are no longer actively maintained live in the [Dormant Projects](.
 - [Nightforce - Ambassadors](https://midnight.network/nightforce-ambassador-program)
 - [Aliit - Technical Fellowship](https://midnight.network/aliit)
 
+## Contributing
 
----
+Pull requests are welcome. The short version:
 
-# Contributing
+1. Add your project in alphabetical order within the appropriate section
+2. Use the format: `[Project Name](link) - Brief description`
+3. Project must include working Compact code, proper attribution, and represent a real use case on Midnight
 
-**Contributions to this repo are welcome! Please:**
-
-1. Add projects in alphabetical order within sections
-2. Use format: `[name](link) - Brief description`
-3. Ensure projects are open source and functional
-
-## Submission Criteria
-
-Projects must include working Compact code, proper attribution, and represent 
-a real use case built on Midnight Network. See [CONTRIBUTING.md](CONTRIBUTING.md) 
-for full review guidelines before opening a PR.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full review guidelines. First-time contributors are especially welcome - feel free to ask in Discord if anything is unclear.
 
 ## License
 
 [![Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+Released under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
Addresses #118

## Summary

Restructures the README to make navigation easier for newcomers, picking up several of the suggestions in #118 without bloating the file. Net change is shorter overall (50 insertions, 72 deletions). Leaving the issue open so the maintainers can decide whether the unaddressed suggestions are still worth pursuing.

## What changed

- Centered the hero header for a cleaner first impression
- Renamed the dApps "Getting Started" section to "Example dApps (Start Here)" to remove a name collision with the Learning Resources subsection of the same name
- Rebuilt the table of contents (the original had stale links to non-existent sections like "Tutorials" and "Community Projects")
- Added the missing Healthcare entry to the TOC
- Normalized header levels: all top-level categories at h2, sub-categories at h3 (the original mixed h1 and h2 inconsistently)
- Removed the stray empty "# Topics" heading and an unused HTML comment
- Promoted Community to its own top-level section
- Folded Submission Criteria into Contributing as a 3-bullet quick reference

## What I deliberately did not do from the issue

- **Beginner/Intermediate/Advanced labels:** subjective per project, would require ongoing relabeling as projects evolve, and would clutter every line
- **Category tags (DeFi/Identity/Gaming/etc.):** the section headers already serve as tags, so adding inline tags would duplicate what the structure already shows

## Verification

- All 90 original URLs preserved (+1 added: midnight.network in the tagline)
- Per-section bullet counts match the original exactly
- All TOC anchors resolve to actual sections
- Every project entry, sub-bullet, callout box, and badge from the original is present
