### PR TITLE
Add Midnight Token Standard (MTS) to Smart Contract Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ smart contracts without connecting to Preprod
 
 ## Smart Contract Primitives
 
+- [Midnight Token Standard (MTS)](https://github.com/nftmakerio/midnight-nft-standard) - Token standard for fungible and non-fungible tokens on Midnight with fully on-chain metadata, supporting both non-programmable (native) and programmable (contract-managed) token types, by NMKR
 - [🔹 OpenZeppelin Compact Contracts](https://github.com/OpenZeppelin/compact-contracts) - Standard contract implementations
   - [🔹 FungibleToken](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/FungibleToken.compact) - ERC-20 equivalent for tokens like stablecoins or rewards
   - [🔹 MultiToken](https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/src/token/MultiToken.compact) - ERC-1155 equivalent supporting both fungible and non-fungible tokens


### PR DESCRIPTION
## Summary

Adds the **Midnight Token Standard (MTS)** to the *Smart Contract Primitives* section.

- Project: [nftmakerio/midnight-nft-standard](https://github.com/nftmakerio/midnight-nft-standard)
- Authored by SAIB, Inc. on behalf of [NMKR](https://www.nmkr.io/)

## What is MTS?

A unified token standard for the Midnight blockchain supporting both fungible and non-fungible tokens with fully on-chain metadata. Inspired by ERC-20/721/1155 and Cardano CIPs, but designed around Midnight's UTXO + privacy architecture.

Key features:
- Dual token types: non-programmable (native) and programmable (contract-managed)
- All token attributes stored on-chain (name, symbol, decimals, description, etc.)
- URI-based media references (IPFS, HTTPS, Arweave)
- Multi-token support: a single contract can manage multiple token types
- Built-in version tracking for future extensibility

## What's in the repo

- `PROPOSAL.md` — full design philosophy and technical specification
- `token_standard.pdf` / `.typ` — formatted specification document
- `examples/cli-demo/` — working CLI demonstration that compiles the Compact contract, deploys it to a Midnight standalone node, mints an NFT with metadata, and queries it back

## Submission criteria checklist

- [x] **Working Compact code** — `examples/cli-demo` contains a functional Compact contract plus end-to-end deploy/mint/query CLI
- [x] **Proper attribution** — README credits SAIB / NMKR and references ERC-20/721/1155 and CIP standards as influences
- [x] **Real use case** — token/NFT standard with reference implementation
- [x] **Open source** — public repository

## Placement

Added under **Smart Contract Primitives** in alphabetical order (before OpenZeppelin Compact Contracts), since this is a token-standard primitive rather than an application.

---

*Note for maintainers: cc @nftmakerio to add the `midnightntwrk` GitHub topic to the source repo per the contributing guide.*
