### PR TITLE
Add Proof-of-Age Gate (Identity & Privacy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [Midnight Authenticator](https://github.com/subc0der/midnight-authenticator) - Zero-knowledge TOTP authenticator that proves code validity without revealing secrets
 - [Midnight Cloak](https://github.com/subc0der/midnight-cloak) - Zero-knowledge identity verification SDK enabling dApps to verify user attributes (age, credentials) without exposing personal data
 - [Private Data Management](https://github.com/Edgxtech/pdm-demo-app) - Private data management demonstration using decentralised ledgers ([article](https://medium.com/itnext/private-data-management-using-decentralised-ledgers-b972c6855e48))
+- [Proof-of-Age Gate](https://github.com/tomiin/midnight-proof-of-age) - Prove you meet a minimum age without revealing your birth year; ZK selective disclosure in Compact, with a React frontend wired to the 1AM wallet
 - [SentinelDID](https://github.com/bytewizard42i/SentinelDID-poc) - ZK identity and access prototype with selective attributes
 - [ZIP](https://github.com/oluwatobiss/zip-midnight-mlh-202605-hack) - A privacy-first Proof-of-Humanity application
 - [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia’s digital sovereignty challenges


### PR DESCRIPTION
Adds the Proof-of-Age Gate to the Identity & Privacy section, in alphabetical order. It lets someone prove they meet a minimum age without revealing their birth year - zero-knowledge selective disclosure written in Compact, with a passing test suite and a React frontend wired to the 1AM wallet via DApp Connector v4. Repo: https://github.com/tomiin/midnight-proof-of-age - Live demo: https://tomiin.github.io/midnight-proof-of-age/ - Open source (Apache-2.0), working Compact code, real use case.