### PR TITLE
docs: move Midnightscan, Tokenless, and midnight_tutorial to dormant projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [Nocturne Wallet](https://github.com/htlabs-xyz/nocturne) - Self-custodial Chrome extension wallet for Midnight with shielded/unshielded balances, DUST registration, multi-network support, and dApp connector - [Chrome Web Store](https://chromewebstore.google.com/detail/nocturne/ijfdfgajlffijenjneoppbfnhjkdibna)
 - [Midnight Playground](https://midnight-playground-one.vercel.app/) - Online Compact IDE for writing, compiling, and building smart contracts with syntax error detection
 - [MidnightForge](https://github.com/bytewizard42i/MidnightForge) - Infrastructure scripts and DevOps for Midnight dApp deployment
-- [Midnightscan](https://github.com/mediocrehacker/Midnightscan) - Blockchain scanner for tracking Midnight contract deployments
 
 - [Nightforge](https://github.com/cadalt0/NIGHTFORGE) - CLI development toolkit for building, deploying, and managing Midnight smart contracts with project scaffolding, compilation, and proof server orchestration
 - [NightGate](https://github.com/ODATANO/NIGHTGATE) - Self contained Midnight Indexer packaged as an SAP CAP plugin normalizes chain data into CAP entities, and exposes it through OData V4 Services.
@@ -108,7 +107,6 @@ _Tools that help other devs build, test, deploy, or index_
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp
 - [Statera Protocol](https://github.com/statera-protocol/statera-protocol-midnight) - Over-collateralized stablecoin protocol with modular dApp framework
-- [Tokenless](https://github.com/luislucena16/tokenless) - Natively Midnight-based asset tokenization system
 
 ## Identity & Privacy
 
@@ -178,7 +176,6 @@ Projects that are no longer actively maintained live in the [Dormant Projects](.
 - [Compact By Example](https://github.com/Olanetsoft/compact-by-example) - Learn Midnight's Compact language through practical, real-world examples
 - [🔹 Edda Labs YouTube Series](https://www.youtube.com/@eddalabs) - In-depth Midnight examples and "Understand the Code" in Spanish, English, and Portuguese
 - [🔹 Mesh Midnight](https://midnight.meshjs.dev/) - A unified repository that brings together packages, examples, and documentation to streamline development
-- [Korean Tutorial](https://github.com/jungmyeong96/midnight_tutorial) - Step-by-step development guide for Korean-speaking developers
 
 
 

--- a/dormant_projects/README.md
+++ b/dormant_projects/README.md
@@ -13,6 +13,7 @@
 
 ## Developer Tools
 - [Midnight Indexer](https://github.com/semsorock/midnight-indexer) - An indexing tool for querying Midnight blockchain data
+- [Midnightscan](https://github.com/mediocrehacker/Midnightscan) - Blockchain scanner for tracking Midnight contract deployments
 
 ## Healthcare
 - [Medical Verification System](https://github.com/FranZavalla/midnight-ui) - A transparent, secure and privacy-preserving protocol for medical data validation and government grants management
@@ -28,8 +29,12 @@
 
 ## Finance & DeFi
 - [Midnight Bank](https://github.com/nel349/midnight-bank) - Privacy-first banking dApp
+- [Tokenless](https://github.com/luislucena16/tokenless) - Natively Midnight-based asset tokenization system
 
 ## Starter Templates
 -  [Scaffold Midnight](https://github.com/kaleababayneh/scaffold-midnight) - Full-stack dev scaffold with Midnight integration
 -  [Wybe](https://github.com/lamg/wybe) - A minimal and expressive contract language for Midnight
 
+
+## Tutorials
+- [Korean Tutorial](https://github.com/jungmyeong96/midnight_tutorial) - Step-by-step development guide for Korean-speaking developers


### PR DESCRIPTION
## Overview

Moves three projects with no meaningful activity in 6+ months from the main list to `dormant_projects/`, per the "Move to dormant" flow in CONTRIBUTING.md. Each entry keeps its original description and lands under the matching category section (Developer Tools / Finance & DeFi / a new Tutorials section).

### Why these three qualify

| Project | Last substantive commit | Evidence |
|---|---|---|
| [Midnightscan](https://github.com/mediocrehacker/Midnightscan) (@mediocrehacker) | 2025-06-16 (Jun 2025 commits were license housekeeping) | 13 months quiet |
| [Tokenless](https://github.com/luislucena16/tokenless) (@luislucena16) | 2025-12-06 | 7.5 months quiet |
| [Korean Tutorial](https://github.com/jungmyeong96/midnight_tutorial) (@jungmyeong96) | 2024-03-06 (final commit 2024-03-30 was a README edit) | 16 months quiet |

Additionally, all three have @claudebarde's "Preprod migration and ecosystem attribution" outreach issue open with **zero responses since February 2026** — the builders have not been reachable through official ecosystem contact for 5 months.

None of these overlap with the projects covered by the earlier #103.

### Courtesy check

Posted a heads-up in the Midnight Discord (#dev-chat) naming all three builders and offering 24 hours to respond before this PR (posted 2026-07-24, 12:24 PM):

![Courtesy check posted in Midnight Discord dev-chat](https://raw.githubusercontent.com/wbaxterh/midnight-awesome-dapps/evidence/courtesy-check-2026-07-24.png)

No builder responses were received within the window (the post drew reactions but no replies). For Midnightscan specifically, this was the **second** unanswered courtesy check: community member Utkarsh Arjariya posted one in the same channel on **2026-06-22**, tagging the builder with the same intent, and also received no response.

(If any builder resurfaces, reverting any single entry is a one-line change — happy to do it. Dormant isn't deleted: the list keeps projects visible for reference, adoption, or revival.)

### Note

[Tech-Expansion/midnight-explorer-web](https://github.com/Tech-Expansion/midnight-explorer-web) doesn't meet the 6-month bar (active until March 2026) but has since been **archived by its owner** — flagging for maintainers to decide whether archived repos should move to dormant immediately; happy to follow up in a separate PR.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — N/A, list-only change
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded — pending
- [ ] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant) — N/A
- [x] No new TODOs introduced

## Links

Guideline followed: [CONTRIBUTING.md → Updating or removing an entry](https://github.com/midnightntwrk/midnight-awesome-dapps/blob/main/CONTRIBUTING.md#updating-or-removing-an-entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
