### PR TITLE
Fix PR thank-you workflow 403 on fork PRs

### DIFF
--- a/.github/workflows/pr-thank-you.yml
+++ b/.github/workflows/pr-thank-you.yml
@@ -3,7 +3,8 @@ name: PR Thank You & Aliit Fellowship
 on:
   pull_request_review:
     types: [submitted]
-  pull_request:
+  # pull_request_target gives a write-capable context for fork PRs on merge.
+  pull_request_target:
     types: [closed]
 
 permissions: {}
@@ -21,12 +22,17 @@ jobs:
       && github.event.pull_request.user.type != 'Bot'
       && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    # issues:write is required: PR comments use the issues comments API.
+    # DEVREL_TRACKER_TOKEN is required for fork PRs: GITHUB_TOKEN is read-only
+    # on pull_request_review events from forks.
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: Post approval comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ secrets.DEVREL_TRACKER_TOKEN }}
           script: |
             const MARKER = '<!-- pr-thank-you-approval -->';
             const pr = context.payload.pull_request;
@@ -76,17 +82,19 @@ jobs:
 
   thank-on-merge:
     if: >-
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request_target'
       && github.event.action == 'closed'
       && github.event.pull_request.merged == true
       && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: Post merge comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ secrets.DEVREL_TRACKER_TOKEN }}
           script: |
             const MARKER = '<!-- pr-thank-you-merge -->';
             const pr = context.payload.pull_request;


### PR DESCRIPTION
## Summary
- The Aliit thank-you workflow was failing on fork PRs with `403 Resource not accessible by integration` when posting comments (seen on #142, #103, and others).
- Root causes:
  1. `GITHUB_TOKEN` is read-only for `pull_request_review` events from forks
  2. Creating PR comments via the issues API also needs `issues: write` (we only granted `pull-requests: write`)
- Fix: use `secrets.DEVREL_TRACKER_TOKEN` (same token as add-to-project), add `issues: write`, and run merge thanks on `pull_request_target`

## Test plan
- [ ] Approve a fork PR and confirm the approval thank-you comment posts
- [ ] Merge a fork PR and confirm the merge thank-you comment posts
- [ ] Re-approve and confirm no duplicate comment
- [ ] Confirm Dependabot / bot PRs are still skipped


