### PR TITLE
fix: CODEOWNERS points at the correctly-spelled codeowners team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @midnightntwrk/mn-codeowners-awsome-dapps
+* @midnightntwrk/mn-codeowners-awesome-dapps
 /.github/ISSUE_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/PULL_REQUEST_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/workflows/scan.yaml @midnightntwrk/mn-security @midnightntwrk/mn-sre


### PR DESCRIPTION
Closes #168

Swaps the catch-all owner from the misspelled `mn-codeowners-awsome-dapps` to `mn-codeowners-awesome-dapps` (membership superset — all 5 members of the typo team are in the correct one, which has 7). **Merge this before the typo team is deleted** (midnight-iac PR) so review routing never breaks; both teams exist today, so this is safe to merge immediately.

_AI-assisted (bot:ai-assisted label unavailable in this repo)._