### PR TITLE
Add Noctis to Finance & DeFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [Midnight Escrow](https://github.com/tusharpamnani/midnight-escrow) - Privacy-preserving escrow contract demonstrating confidential conditional payments using zk proofs on Midnight
 - [Midnight Private Auction](https://github.com/pplmaverick/midnight-private-auction) - Sealed-bid auction on Midnight using Compact private state so bid amounts stay private until reveal. - [Demo](https://midnight-private-auction.vercel.app)
 - [MidPilot](https://github.com/ANPAN27/MidPilot) - AI spending assistant for Midnight that plans transfers with local policy checks and MCP wallet integration. - [Demo](https://midpilot.vercel.app)
+- [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private buying phase on Midnight, where buy amounts stay hidden while the contract proves no wallet exceeded its cap. - [Site](https://noctis.zone)
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
 - [SilentBid](https://github.com/efekrbas/midnight-sealed-bid-marketplace) - A zero-knowledge sealed-bid marketplace where bids stay private until settlement.
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp


### PR DESCRIPTION
## Overview

Adds [Noctis](https://github.com/NoctisZone/Noctis) to **Finance & DeFi**, in alphabetical order between MidPilot and Pintent.

Noctis is a token launchpad. Its DarkVeil phase runs the sale privately on Midnight, so buy amounts stay hidden while the contract still proves no wallet exceeded its 5% cap. Token, bonding curve and liquidity settle on Cardano.

The repository contains 8 Compact contracts under `contracts/midnight/`: bonding curve, eligibility gate, creator escrow, treasury, vesting, LP escrow, CTO governance and staking pool.

## Ecosystem attribution

- **Step 1 — GitHub topics:** `midnightntwrk` present, alongside `compact`.
- **Step 2 — README attribution sentence:** "This project is built on the Midnight Network." appears near the top of the project README.
- **Step 3 — this pull request.**

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — not applicable, list entry only
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded — CLA signature outstanding, see below
- [x] Self-reviewed the diff
- [x] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant) — not applicable
- [x] No new TODOs introduced

Also confirmed against the quick checklist: the project is not already listed, the repository is public and open source (Apache-2.0), the entry is one factual sentence ending in a period, and it links to the primary repository.

## Links

Project: https://github.com/NoctisZone/Noctis
Site: https://noctis.zone