### PR TITLE
Add Anonboard to EffectStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   - [Developer Tools](#developer-tools)
   - [Finance \& DeFi](#finance--defi)
   - [Identity \& Privacy](#identity--privacy)
-  - [EffectStream](#effectstream)
   - [Gaming](#gaming)
   - [Governance](#governance)
   - [Dormant Projects](#dormant-projects)
@@ -115,6 +114,7 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 
 - [🔹 Midnight Identity](https://github.com/bricktowers/midnight-identity) - Brick Towers' ZK identity system for self-issued credentials
 - [AirLog](https://github.com/hbrazier01/airlog) - Privacy preserving aviation maintenance record verification system built with Midnight Compact smart contracts
+- [Anonboard](https://github.com/nel349/solana-anonboard) - Anonymous bulletin board that proves membership with a zero-knowledge circuit on Midnight, while posts are stored publicly and gaslessly on Solana, linked by an EffectStream sync node.
 - [Credence](https://github.com/0xfdbu/midnight-apps/tree/main/fullstack-dapp) - Fullstack ZK identity platform for privacy-preserving credential attestations — authorities attest users via Merkle-tree commitments; users prove eligibility without revealing identity using nullifier-protected ZK proofs, with deterministic key derivation
 - [AutoDiscovery](https://github.com/SpyCrypto/AutoDiscovery) - Privacy-preserving legal discovery automation with jurisdiction-aware compliance, ZK proofs, and dual-ledger architecture
 - [DPO2U Midnight](https://github.com/fredericosanntana/dpo2u-midnight) - Autonomous LGPD/GDPR compliance protocol with ZK-attested privacy scores. AI agents audit data protection practices off-chain and record immutable attestations on Midnight via four Compact smart contracts (ComplianceRegistry, AgentRegistry, FeeDistributor, Treasury)
@@ -127,12 +127,6 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [SentinelDID](https://github.com/bytewizard42i/SentinelDID-poc) - ZK identity and access prototype with selective attributes
 - [ZIP](https://github.com/oluwatobiss/zip-midnight-mlh-202605-hack) - A privacy-first Proof-of-Humanity application
 - [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia’s digital sovereignty challenges
-
-## EffectStream
-
-_DApps built on the [EffectStream](https://effectstream.dev) cross-chain sync framework, bridging Midnight with another chain_
-
-- [Anonboard](https://github.com/nel349/solana-anonboard) - Anonymous bulletin board that proves the right to post with a zero-knowledge membership circuit on Midnight, while posts are stored publicly and gaslessly on Solana, linked by an EffectStream sync node.
 
 # Topics
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Developer Tools](#developer-tools)
   - [Finance \& DeFi](#finance--defi)
   - [Identity \& Privacy](#identity--privacy)
+  - [EffectStream](#effectstream)
   - [Gaming](#gaming)
   - [Governance](#governance)
   - [Dormant Projects](#dormant-projects)
@@ -126,6 +127,12 @@ _Privacy-preserving identity, credentials, and proof of personhood_
 - [SentinelDID](https://github.com/bytewizard42i/SentinelDID-poc) - ZK identity and access prototype with selective attributes
 - [ZIP](https://github.com/oluwatobiss/zip-midnight-mlh-202605-hack) - A privacy-first Proof-of-Humanity application
 - [zkTanitID](https://github.com/carthagexlabs/zk-tanit-id) - Privacy-Preserving Identity Attestations, inspired by Tunisia’s digital sovereignty challenges
+
+## EffectStream
+
+_DApps built on the [EffectStream](https://effectstream.dev) cross-chain sync framework, bridging Midnight with another chain_
+
+- [Anonboard](https://github.com/nel349/solana-anonboard) - Anonymous bulletin board that proves the right to post with a zero-knowledge membership circuit on Midnight, while posts are stored publicly and gaslessly on Solana, linked by an EffectStream sync node.
 
 # Topics
 


### PR DESCRIPTION
## Overview

Adds **Anonboard** to the list, under a new **EffectStream** section.

Anonboard is an anonymous bulletin board: the right to post is proven in a Compact zero-knowledge circuit on Midnight, while the posts themselves are stored publicly and gaslessly on Solana. An [EffectStream](https://effectstream.dev) sync node reads both chains and ties them together through an anonymous badge, so a post can be marked as a member's without revealing which member wrote it.

I added a new section because EffectStream-based DApps span two chains and do not fit cleanly under a single purpose section. Happy to re-file the entry under **Identity & Privacy** instead if reviewers prefer to keep the list organized by purpose.

- Repository: https://github.com/nel349/solana-anonboard
- Compact contract: `packages/contracts-midnight/contract-anonboard` (membership + join circuits, with simulator tests)
- Runs locally against the `undeployed` network; end-to-end suite is green.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [x] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new TODOs introduced

Ecosystem attribution steps on the submitted repository:

- [x] **Step 1:** `midnightntwrk` topic added (plus `compact`)
- [x] **Step 2:** README includes the exact sentence "This project is built on the Midnight Network."
- [x] **Step 3:** This pull request