### PR TITLE
Update the Noctis entry description

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [Midnight Escrow](https://github.com/tusharpamnani/midnight-escrow) - Privacy-preserving escrow contract demonstrating confidential conditional payments using zk proofs on Midnight
 - [Midnight Private Auction](https://github.com/pplmaverick/midnight-private-auction) - Sealed-bid auction on Midnight using Compact private state so bid amounts stay private until reveal. - [Demo](https://midnight-private-auction.vercel.app)
 - [MidPilot](https://github.com/ANPAN27/MidPilot) - AI spending assistant for Midnight that plans transfers with local policy checks and MCP wallet integration. - [Demo](https://midpilot.vercel.app)
-- [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private buying phase on Midnight, where buy amounts stay hidden while the contract proves no wallet exceeded its cap. - [Site](https://noctis.zone)
+- [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private Midnight buying phase: amounts stay hidden until reveal, when the contract checks the per-wallet cap. - [Site](https://noctis.zone)
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
 - [SilentBid](https://github.com/efekrbas/midnight-sealed-bid-marketplace) - A zero-knowledge sealed-bid marketplace where bids stay private until settlement.
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp


### PR DESCRIPTION
## Overview

A one-line edit to the Noctis entry in **Finance & DeFi**, taking the wording @oduameh suggested while reviewing #170.

**Before**

> Token launchpad with a private buying phase on Midnight, where buy amounts stay hidden while the contract proves no wallet exceeded its cap.

**After**

> Token launchpad with a private Midnight buying phase: amounts stay hidden until reveal, when the contract checks the per-wallet cap.

The original line reads as though the cap is enforced against hidden amounts, and it is not. `submitBuyCommit` stores a commitment only; the cap is checked in `revealBuyCommit`, at which point the amount is public by design. The new wording describes what the contract actually does, and is the more useful description for anyone browsing the list.

Nothing else changes: same project, same links, same alphabetical position between MidPilot and Pintent.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — not applicable, one list line
- [x] Key commits have useful messages
- [x] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [x] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant) — not applicable
- [x] No new TODOs introduced

Entry format re-checked against CONTRIBUTING.md: one factual, non-promotional sentence ending in a period, linking the primary repository.

## Links

Follow-up to #170 · review: https://github.com/midnightntwrk/midnight-awesome-dapps/pull/170#pullrequestreview-5030104767

Project: https://github.com/NoctisZone/Noctis
