### PR TITLE
Add Selkie to Finance & DeFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [MidPilot](https://github.com/ANPAN27/MidPilot) - AI spending assistant for Midnight that plans transfers with local policy checks and MCP wallet integration. - [Demo](https://midpilot.vercel.app)
 - [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private Midnight buying phase: amounts stay hidden until reveal, when the contract checks the per-wallet cap. - [Site](https://noctis.zone)
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
+- [Selkie](https://github.com/DpacJones/selkie-usdm-escrow) - Escrow that holds USDM in contract state and releases it to whoever proves knowledge of a secret, with no identity check in the claim path.
 - [SilentBid](https://github.com/efekrbas/midnight-sealed-bid-marketplace) - A zero-knowledge sealed-bid marketplace where bids stay private until settlement.
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp
 


### PR DESCRIPTION
## Overview

Adds **Selkie** to the Finance & DeFi section.

Selkie is an escrow on Midnight Preview that settles in USDM, the stablecoin that moves natively between Cardano and Midnight through VIA Labs cross-chain messaging. A depositor locks USDM behind a commitment, and whoever proves knowledge of the matching secret claims it. There is no allowlist, no signature check, and no identity in the claim path .. possession of the secret is the authorization, and the secret itself is a witness that never reaches the chain.

USDM is handled at the **contract layer**, not the application layer: `create_escrow` calls `receiveUnshielded` and `claim`/`cancel` call `sendUnshielded`, so the tokens sit in contract state between the two. The token color is a `sealed ledger` field fixed at deployment.

- Repository: https://github.com/DpacJones/selkie-usdm-escrow
- Deployed on Midnight Preview: `e4fc8d6614ab5abf60fbe7b14e1968a98797e405b4cdc6c6f5214c9b536b56bd`
- Verified on-chain: a 2.5 USDM `create_escrow` then `claim`, with the wallet balance moving 10.0 → 7.5 → 10.0 USDM.

The README is explicit about what is and is not private: the secrets are private, but USDM is an unshielded token, so amounts and settlement addresses are public. Selkie provides possession-based authorization without an identity registry, not payment privacy. A known gap (cancel has no deadline, so the payee has no settlement guarantee) is documented rather than omitted.

Ecosystem attribution is in place on the project repository: topics `midnightntwrk` and `compact`, and the exact attribution sentence near the top of the README.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible) .. 30 in-process contract tests in the project repository
- [x] Key commits have useful messages
- [x] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [x] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new TODOs introduced

Entry is one sentence, factual, ends with a period, and is placed in alphabetical order between Pintent and SilentBid.