### PR TITLE
Add nite-zk-profiler to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [Night Check](https://github.com/CjDabrow/night-check) - Reviews Compact contracts and SDK code for Midnight-specific privacy and security issues, and certifies a review on-chain with a privacy-preserving Compact contract. - [Website](https://midnight.gridservices.xyz)
 - [Nightforge](https://github.com/cadalt0/NIGHTFORGE) - CLI development toolkit for building, deploying, and managing Midnight smart contracts with project scaffolding, compilation, and proof server orchestration
 - [NightGate](https://github.com/ODATANO/NIGHTGATE) - Self contained Midnight Indexer packaged as an SAP CAP plugin normalizes chain data into CAP entities, and exposes it through OData V4 Services.
+- [Nite ZK Profiler](https://github.com/nite-framework/nite-zk-profiler) - See what a Compact circuit costs to prove without generating proving keys. Reports rows and `k` per circuit, and gates proving cost regressions in CI.
 - [Pelagos SDK](https://github.com/0xAtelerix/sdk) - Go SDK for building appchains with native Midnight, EVM, and non-EVM integration
 
 ## Finance & DeFi

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [Night Check](https://github.com/CjDabrow/night-check) - Reviews Compact contracts and SDK code for Midnight-specific privacy and security issues, and certifies a review on-chain with a privacy-preserving Compact contract. - [Website](https://midnight.gridservices.xyz)
 - [Nightforge](https://github.com/cadalt0/NIGHTFORGE) - CLI development toolkit for building, deploying, and managing Midnight smart contracts with project scaffolding, compilation, and proof server orchestration
 - [NightGate](https://github.com/ODATANO/NIGHTGATE) - Self contained Midnight Indexer packaged as an SAP CAP plugin normalizes chain data into CAP entities, and exposes it through OData V4 Services.
-- [Nite ZK Profiler](https://github.com/nite-framework/nite-zk-profiler) - See what a Compact circuit costs to prove without generating proving keys. Reports rows and `k` per circuit, and gates proving cost regressions in CI.
+- [Nite ZK Profiler](https://github.com/nite-framework/nite-zk-profiler) - CLI that reports Compact circuit proving cost (rows and k) without generating proving keys, and can fail CI when a circuit exceeds a maxK budget. - [npm](https://www.npmjs.com/package/@nite-framework/nite-zk-profiler)
 - [Pelagos SDK](https://github.com/0xAtelerix/sdk) - Go SDK for building appchains with native Midnight, EVM, and non-EVM integration
 
 ## Finance & DeFi


### PR DESCRIPTION
Adds `nite-zk-profiler`, a CLI that reports what each circuit in a Compact contract costs to prove, without generating proving keys.

**What it does**: Runs `compact compile --skip-zk`, then the version-paired `zkir mock-compile` per circuit, and reports rows, `k`, capacity and relative proving cost. A committed `zk-budget.json` declares a `maxK` ceiling per circuit, and `check` exits nonzero when one is exceeded, so it drops into CI as a single step.

**Why it is useful**: Proving cost rises in steps, not smoothly, and `k` is not a function of how much code you wrote. Two circuits measured at 24 rows each report k=5 and k=7; a 119 row circuit lands at k=9 while a 191 row circuit lands at k=8. None of that is visible in the source, and the only way to find out previously was to generate proving keys and time a real proof, which is far too slow for an edit loop.

### Links

**Repository**: https://github.com/nite-framework/nite-zk-profiler
**npm** : https://www.npmjs.com/package/@nite-framework/nite-zk-profiler
**License**: MIT
**Status**: Published and working against Compact toolchain 0.31.x. Built under an approved Midnight Developer Tools bounty and reviewed by the Midnight team. 59 tests, CI on every push, releases published from tags with npm provenance.