### PR TITLE
Add MintKey to Finance & DeFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [Midnight Escrow](https://github.com/tusharpamnani/midnight-escrow) - Privacy-preserving escrow contract demonstrating confidential conditional payments using zk proofs on Midnight
 - [Midnight Private Auction](https://github.com/pplmaverick/midnight-private-auction) - Sealed-bid auction on Midnight using Compact private state so bid amounts stay private until reveal. - [Demo](https://midnight-private-auction.vercel.app)
 - [MidPilot](https://github.com/ANPAN27/MidPilot) - AI spending assistant for Midnight that plans transfers with local policy checks and MCP wallet integration. - [Demo](https://midpilot.vercel.app)
+- [MintKey](https://github.com/ErickRomeroDev/embedded-wallet-shielded-token) - Passkey-owned shielded token mint on Midnight, with a browser-embedded wallet derived from a WebAuthn passkey and mint and burn gated by a ZK owner-commitment proof.
 - [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private Midnight buying phase: amounts stay hidden until reveal, when the contract checks the per-wallet cap. - [Site](https://noctis.zone)
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
 - [Selkie](https://github.com/DpacJones/selkie-usdm-escrow) - Escrow that holds USDM in contract state and releases it to whoever proves knowledge of a secret, with no identity check in the claim path.


### PR DESCRIPTION
## Overview

Adds MintKey to the Finance & DeFi section.

MintKey is a passkey-owned shielded token mint on Midnight. A WebAuthn passkey derives both the in-browser Midnight wallet (PRF → HKDF → wallet SDK) and the owner secret, so mint and burn are gated by a ZK proof that the caller knows the preimage of the owner commitment stored on-chain. The full shielded-token flow — sync, balance, balancing, signing, submission — runs in the browser with no extension dependency.

The repository vendors OpenZeppelin Compact modules (`access/Ownable`, `shielded-token/NativeShieldedToken*`, `utils/Utils`, v0.3.0-alpha.1, MIT) and credits them in the README. Apache-2.0 licensed. The end-to-end flow is covered by the `E2E (standalone)` workflow on amd64 and arm64 runners.

**Step 1 (topic):** https://github.com/ErickRomeroDev/embedded-wallet-shielded-token — `midnightntwrk`, `compact`
**Step 2 (attribution):** "This project is built on the Midnight Network." near the top of the [project README](https://github.com/ErickRomeroDev/embedded-wallet-shielded-token#readme)

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new TODOs introduced
