### PR TITLE
Add Private Invoices to Finance & DeFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [MidPilot](https://github.com/ANPAN27/MidPilot) - AI spending assistant for Midnight that plans transfers with local policy checks and MCP wallet integration. - [Demo](https://midpilot.vercel.app)
 - [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private Midnight buying phase: amounts stay hidden until reveal, when the contract checks the per-wallet cap. - [Site](https://noctis.zone)
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
+- [Private Invoices](https://github.com/CjDabrow/midnight-private-invoices) - Invoice registry where the amount and counterparty stay private and settlement is proven in zero knowledge, paid in USDM, which moves natively between Cardano and Midnight through VIA. - [Demo](https://cjdabrow.github.io/midnight-private-invoices/)
 - [Selkie](https://github.com/DpacJones/selkie-usdm-escrow) - Escrow that holds USDM in contract state and releases it to whoever proves knowledge of a secret, with no identity check in the claim path.
 - [SilentBid](https://github.com/efekrbas/midnight-sealed-bid-marketplace) - A zero-knowledge sealed-bid marketplace where bids stay private until settlement.
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ _Tools that help other devs build, test, deploy, or index_
 - [MidPilot](https://github.com/ANPAN27/MidPilot) - AI spending assistant for Midnight that plans transfers with local policy checks and MCP wallet integration. - [Demo](https://midpilot.vercel.app)
 - [Noctis](https://github.com/NoctisZone/Noctis) - Token launchpad with a private Midnight buying phase: amounts stay hidden until reveal, when the contract checks the per-wallet cap. - [Site](https://noctis.zone)
 - [Pintent](https://github.com/0xAtelerix/pintent) - Cross-chain bridge from Midnight to EVM and non-EVM chains using an intent-based solver model
-- [Private Invoices](https://github.com/CjDabrow/midnight-private-invoices) - Invoice registry where the amount and counterparty stay private and settlement is proven in zero knowledge, paid in USDM, which moves natively between Cardano and Midnight through VIA. - [Demo](https://cjdabrow.github.io/midnight-private-invoices/)
+- [Private Invoices](https://github.com/CjDabrow/midnight-private-invoices) - Invoice registry on Midnight that stores a commitment on-chain and settles it with a zero-knowledge proof of the private amount, payer, and salt. - [Demo](https://cjdabrow.github.io/midnight-private-invoices/)
 - [Selkie](https://github.com/DpacJones/selkie-usdm-escrow) - Escrow that holds USDM in contract state and releases it to whoever proves knowledge of a secret, with no identity check in the claim path.
 - [SilentBid](https://github.com/efekrbas/midnight-sealed-bid-marketplace) - A zero-knowledge sealed-bid marketplace where bids stay private until settlement.
 - [SilentLedger](https://github.com/bytewizard42i/SilentLedger) - A privacy-preserving verified orderbook dApp


### PR DESCRIPTION
## Overview

Adds Private Invoices to the Finance & DeFi section: an invoice registry DApp on Midnight Preview where the amount and counterparty stay private and settlement is proven in zero knowledge. Payments use USDM, which moves natively between Cardano and Midnight through VIA.

- Repo: https://github.com/CjDabrow/midnight-private-invoices (topics `midnightntwrk`, `compact`; attribution sentence at the top of the README)
- Deployed contract (Preview): `3340415ce4cb387a51cec39897d9f0dc5152b843ca3a41eb16b5960ea549458c` with post-deploy interactions listed in the README
- Entry is alphabetized within the section and follows the `[Name](link) - description.` format

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new TODOs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)